### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/braccioOfUnoWiFi/braccioOfUnoWiFi.ino
+++ b/examples/braccioOfUnoWiFi/braccioOfUnoWiFi.ino
@@ -48,7 +48,7 @@ int m4 = 180;
 int m5 = 90;
 int m6 = 0;
 
-boolean moveBraccio = false;
+bool moveBraccio = false;
 
 Servo base;
 Servo shoulder;

--- a/examples/ciaoBraccio/ciaoBraccio.ino
+++ b/examples/ciaoBraccio/ciaoBraccio.ino
@@ -35,7 +35,7 @@ int m4 = 180;
 int m5 = 90;
 int m6 = 0;
 
-boolean moveBraccio = false;
+bool moveBraccio = false;
 
 Servo base;
 Servo shoulder;


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633