### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Braccio
-version=2.0.3
+version=2.0.4
 author=Andrea Martino, Arduino
 maintainer=Arduino <swdev@arduino.org>
 sentence=Allows to move each Braccio parts using simple calls.

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Works only for TinkerKit Braccio.
 category=Device Control
 url=https://store.arduino.cc/tinkerkit-braccio
 architectures=avr, samd, sam
+depends=Servo


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format