### PR TITLE
Bugfix to how ServoMovement sets wrist rotation/vertical position

### DIFF
--- a/src/Braccio.cpp
+++ b/src/Braccio.cpp
@@ -188,30 +188,30 @@ int _Braccio::ServoMovement(int stepDelay, int vBase, int vShoulder, int vElbow,
 
 		}
 
-		if (vWrist_ver != step_wrist_rot) 
+		if (vWrist_ver != step_wrist_ver)
 		{
-			wrist_rot.write(step_wrist_rot);
+			wrist_ver.write(step_wrist_ver);
 			//One step ahead
-			if (vWrist_ver > step_wrist_rot) {
-				step_wrist_rot++;				
+			if (vWrist_ver > step_wrist_ver) {
+				step_wrist_ver++;
 			}
 			//One step beyond
-			if (vWrist_ver < step_wrist_rot) {
-				step_wrist_rot--;
+			if (vWrist_ver < step_wrist_ver) {
+				step_wrist_ver--;
 			}
 
 		}
 
-		if (vWrist_rot != step_wrist_ver)
+		if (vWrist_rot != step_wrist_rot)
 		{
-			wrist_ver.write(step_wrist_ver);
+			wrist_rot.write(step_wrist_rot);
 			//One step ahead
-			if (vWrist_rot > step_wrist_ver) {
-				step_wrist_ver++;
+			if (vWrist_rot > step_wrist_rot) {
+				step_wrist_rot++;
 			}
 			//One step beyond
-			if (vWrist_rot < step_wrist_ver) {
-				step_wrist_ver--;
+			if (vWrist_rot < step_wrist_rot) {
+				step_wrist_rot--;
 			}
 		}
 
@@ -232,13 +232,13 @@ int _Braccio::ServoMovement(int stepDelay, int vBase, int vShoulder, int vElbow,
 		
 		//It checks if all the servo motors are in the desired position 
 		if ((vBase == step_base) && (vShoulder == step_shoulder)
-				&& (vElbow == step_elbow) && (vWrist_ver == step_wrist_rot)
-				&& (vWrist_rot == step_wrist_ver) && (vgripper == step_gripper)) {
+				&& (vElbow == step_elbow) && (vWrist_ver == step_wrist_ver)
+				&& (vWrist_rot == step_wrist_rot) && (vgripper == step_gripper)) {
 			step_base = vBase;
 			step_shoulder = vShoulder;
 			step_elbow = vElbow;
-			step_wrist_rot = vWrist_ver;
-			step_wrist_ver = vWrist_rot;
+			step_wrist_rot = vWrist_rot;
+			step_wrist_ver = vWrist_ver;
 			step_gripper = vgripper;
 			exit = 0;
 		} else {

--- a/src/Braccio.cpp
+++ b/src/Braccio.cpp
@@ -59,8 +59,8 @@ unsigned int _Braccio::begin(int soft_start_level) {
 	base.attach(11);
 	shoulder.attach(10);
 	elbow.attach(9);
-	wrist_rot.attach(6);
-	wrist_ver.attach(5);
+    wrist_ver.attach(6);
+    wrist_rot.attach(5);
 	gripper.attach(3);
         
 	//For each step motor this set up the initial degree


### PR DESCRIPTION
Fix a bug in the ServoMovement method where it compared the wrong Wrist vertical/rotation attributes when calculating the current/target servo positions.

This was causing some strange glitches between the 'soft start' and user-set positions.  