### PR TITLE
Change maintainer to `Arduino <info@arduino.cc>`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Braccio
 version=2.0.4
 author=Andrea Martino, Arduino
-maintainer=Arduino <swdev@arduino.org>
+maintainer=Arduino <info@arduino.cc>
 sentence=Allows moving each Braccio part using simple calls.
 paragraph=Works only for TinkerKit Braccio.
 category=Device Control


### PR DESCRIPTION
Maintainer is changed from `Arduino <swdev@arduino.org>` to `Arduino <info@arduino.cc>` within the `library.properties` file. 